### PR TITLE
Support windows for getting master password

### DIFF
--- a/visionarypm/__init__.py
+++ b/visionarypm/__init__.py
@@ -4,11 +4,24 @@ from __future__ import print_function, unicode_literals
 import codecs
 
 from colorama import init, Fore, Style
-from getpass import getpass
 import pyscrypt
 import json
 import os
+import sys
 
+if sys.version_info < (3,) and sys.platform.startswith('win'):
+    from getpass import getpass as _getpass
+    def getpass(s):
+        try:
+            return _getpass(str(s))
+        except UnicodeEncodeError:
+            from locale import getpreferredencoding
+            try:
+                return _getpass(s.encode(getpreferredencoding()))
+            except UnicodeEncodeError:
+                return _getpass(b'Password: ')
+else:
+    from getpass import getpass
 
 # Initialise colours for multi-platform support.
 init()

--- a/visionarypm/__init__.py
+++ b/visionarypm/__init__.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 
+# workaround from https://bitbucket.org/ZyX_I/gibiexport/commits/a1241335fe53
 if sys.version_info < (3,) and sys.platform.startswith('win'):
     from getpass import getpass as _getpass
     def getpass(s):


### PR DESCRIPTION
On windows with python 2.7, getpass fails with the "TypeError: must be char, not unicode" error.
I've added a quick fix taken from https://bitbucket.org/ZyX_I/gibiexport/commits/a1241335fe53
